### PR TITLE
Added onRestoreStateForActivityResult to take care of case

### DIFF
--- a/src/android/FileChooser.java
+++ b/src/android/FileChooser.java
@@ -6,7 +6,6 @@ import android.net.Uri;
 import android.util.Log;
 import android.os.Bundle;
 
-
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
@@ -51,7 +50,6 @@ public class FileChooser extends CordovaPlugin {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-                
         if (requestCode == PICK_FILE_REQUEST && callback != null) {
 
             if (resultCode == Activity.RESULT_OK) {

--- a/src/android/FileChooser.java
+++ b/src/android/FileChooser.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
+import android.os.Bundle;
+
 
 import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CallbackContext;
@@ -49,7 +51,7 @@ public class FileChooser extends CordovaPlugin {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-
+                
         if (requestCode == PICK_FILE_REQUEST && callback != null) {
 
             if (resultCode == Activity.RESULT_OK) {
@@ -78,5 +80,11 @@ public class FileChooser extends CordovaPlugin {
                 callback.error(resultCode);
             }
         }
+    }
+
+
+    public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {
+        this.callback = callbackContext;
+        Log.d(TAG,"onRestoreStateForActivityResult------------");
     }
 }


### PR DESCRIPTION
This is a minimal change that I noticed was required to ensure that results from calling the FileChooser plugin were available to the calling cordova app (Actvity) even after it was destroyed by Android due to scarce resources.
 Beyond this small change, I needed to then define a handler for the 'resume' event in my cordova app javascript, which would make sense of the results-bearing event object passed to it by the cordova infrastructure.
