### PR TITLE
Adding mimeType filtering for windows

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "cSpell.words": [
+    "chooser",
+    "cordova",
+    "file",
+    "plugin"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  "cSpell.words": [
-    "chooser",
-    "cordova",
-    "file",
-    "plugin"
-  ]
-}

--- a/README.md
+++ b/README.md
@@ -1,31 +1,48 @@
-Cordova FileChooser Plugin
+# Cordova FileChooser Plugin
 
 Requires Cordova >= 2.8.0
 
-Install with Cordova CLI
-	
-	$ cordova plugin add http://github.com/don/cordova-filechooser.git
+## Install with Cordova CLI
 
-Install with Plugman 
+```bash
+cordova plugin add http://github.com/don/cordova-filechooser.git
+```
 
-	$ plugman --platform android --project /path/to/project \ 
-		--plugin http://github.com/don/cordova-filechooser.git
+## Install with Plugman
 
-API
+```bash
+plugman --platform android --project /path/to/project \
+--plugin http://github.com/don/cordova-filechooser.git
+```
 
-	fileChooser.open(successCallback, failureCallback);
+## API
 
-The success callback get the uri of the selected file
+```javascript
+fileChooser.open(filter, successCallback, failureCallback); // with mime filter
 
-	fileChooser.open(function(uri) {
-		alert(uri);
-	});
-	
-Screenshot
+fileChooser.open(successCallback. failureCallback); // without mime filter
+```
+
+### Filter (Optional)
+
+```javascript
+{ "mime": "application/pdf" }  // text/plain, image/png, image/jpeg, audio/wav etc
+```
+
+The success callback gets the uri of the selected file
+
+```javascript
+fileChooser.open(function(uri) {
+alert(uri);
+});
+```
+
+## Screenshot
 
 ![Screenshot](filechooser.png "Screenshot")
 
-Supported Platforms:
+## Supported Platforms
+
 - Android
 - Windows (UWP)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The success callback gets the uri of the selected file
 
 ```javascript
 fileChooser.open(function(uri) {
-alert(uri);
+	alert(uri);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Requires Cordova >= 2.8.0
 
 Install with Cordova CLI
 	
-	$ cordova plugin add http://github.com/don/cordova-filechooser.git
+	$ cordova plugin add http://github.com/ihadeed/cordova-filechooser.git
 
 Install with Plugman 
 
 	$ plugman --platform android --project /path/to/project \ 
-		--plugin http://github.com/don/cordova-filechooser.git
+		--plugin http://github.com/ihadeed/cordova-filechooser.git
 
 API
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Requires Cordova >= 2.8.0
 ## Install with Cordova CLI
 
 ```bash
-cordova plugin add http://github.com/don/cordova-filechooser.git
+cordova plugin add http://github.com/hibeekaey/cordova-filechooser.git
 ```
 
 ## Install with Plugman
 
 ```bash
 plugman --platform android --project /path/to/project \
---plugin http://github.com/don/cordova-filechooser.git
+--plugin http://github.com/hibeekaey/cordova-filechooser.git
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -25,4 +25,8 @@ Screenshot
 
 ![Screenshot](filechooser.png "Screenshot")
 
+Supported Platforms:
+- Android
+- Windows (UWP)
+
 TODO rename `open` to pick, select, or choose.

--- a/README.md
+++ b/README.md
@@ -5,18 +5,9 @@ Requires Cordova >= 2.8.0
 ## Install with Cordova CLI
 	$ cordova plugin add http://github.com/ihadeed/cordova-filechooser.git
 
-```bash
-cordova plugin add http://github.com/hibeekaey/cordova-filechooser.git
-```
-
 ## Install with Plugman
 	$ plugman --platform android --project /path/to/project \ 
 		--plugin http://github.com/ihadeed/cordova-filechooser.git
-
-```bash
-plugman --platform android --project /path/to/project \
---plugin http://github.com/hibeekaey/cordova-filechooser.git
-```
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The success callback gets the uri of the selected file
 
 ```javascript
 fileChooser.open(function(uri) {
-alert(uri);
+  alert(uri);
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cordova-plugin-filechooser",
+  "version": "1.0.1",
+  "description": "Cordova FileChooser Plugin",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ihadeed/cordova-filechooser.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ihadeed/cordova-filechooser/issues"
+  },
+  "homepage": "https://github.com/ihadeed/cordova-filechooser#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-filechooser",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Cordova FileChooser Plugin",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-filechooser",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cordova FileChooser Plugin",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,12 @@
   "bugs": {
     "url": "https://github.com/ihadeed/cordova-filechooser/issues"
   },
-  "homepage": "https://github.com/ihadeed/cordova-filechooser#readme"
+  "homepage": "https://github.com/ihadeed/cordova-filechooser#readme",
+  "cordova": {
+    "id": "cordova-plugin-filechooser",
+    "platforms": [
+      "android",
+      "windows"
+    ]
+  }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,5 +26,11 @@
         <source-file src="src/android/FileChooser.java" target-dir="src/com/megster/cordova"/>
                         
     </platform>
+
+    <platform name="windows">
+        <js-module src="src/windows/FileChooserProxy.js" name="FileChooserProxy">
+            <runs />
+        </js-module>
+    </platform>
     
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.phonegap.com/ns/plugins/1.0" 
     xmlns:android="http://schemas.android.com/apk/res/android" 
     id="cordova-plugin-filechooser" 
-    version="1.0.1">
+    version="1.1.0">
     
     <engines>
         <engine name="cordova" version=">=2.8.0" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,8 +2,8 @@
 <plugin 
     xmlns="http://www.phonegap.com/ns/plugins/1.0" 
     xmlns:android="http://schemas.android.com/apk/res/android" 
-    id="com.megster.cordova.FileChooser" 
-    version="0.0.0">
+    id="cordova-plugin-filechooser" 
+    version="1.0.1">
     
     <engines>
         <engine name="cordova" version=">=2.8.0" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     xmlns="http://www.phonegap.com/ns/plugins/1.0" 
     xmlns:android="http://schemas.android.com/apk/res/android" 
     id="cordova-plugin-filechooser" 
-    version="1.1.0">
+    version="1.2.0">
     
     <engines>
         <engine name="cordova" version=">=2.8.0" />

--- a/src/android/FileChooser.java
+++ b/src/android/FileChooser.java
@@ -5,36 +5,42 @@ import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
 
-import org.apache.cordova.CordovaArgs;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 public class FileChooser extends CordovaPlugin {
 
     private static final String TAG = "FileChooser";
     private static final String ACTION_OPEN = "open";
     private static final int PICK_FILE_REQUEST = 1;
+
+    public static final String MIME = "mime";
+
     CallbackContext callback;
 
     @Override
-    public boolean execute(String action, CordovaArgs args, CallbackContext callbackContext) throws JSONException {
+    public boolean execute(String action, JSONArray inputs, CallbackContext callbackContext) throws JSONException {
 
         if (action.equals(ACTION_OPEN)) {
-            chooseFile(callbackContext);
+            JSONObject filters = inputs.optJSONObject(0);
+            chooseFile(filters, callbackContext);
             return true;
         }
 
         return false;
     }
 
-    public void chooseFile(CallbackContext callbackContext) {
+    public void chooseFile(JSONObject filter, CallbackContext callbackContext) {
+        String uri_filter = filter.has(MIME) ? filter.optString(MIME) : "*/*";
 
         // type and title should be configurable
 
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-        intent.setType("*/*");
+        intent.setType(uri_filter);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.putExtra(Intent.EXTRA_LOCAL_ONLY, true);
 

--- a/src/android/FileChooser.java
+++ b/src/android/FileChooser.java
@@ -74,11 +74,9 @@ public class FileChooser extends CordovaPlugin {
                 }
 
             } else if (resultCode == Activity.RESULT_CANCELED) {
-
-                // TODO NO_RESULT or error callback?
-                PluginResult pluginResult = new PluginResult(PluginResult.Status.NO_RESULT);
-                callback.sendPluginResult(pluginResult);
-
+                // keep this string the same as in iOS document picker plugin
+                // https://github.com/iampossible/Cordova-DocPicker
+                callback.error("User canceled.");
             } else {
 
                 callback.error(resultCode);

--- a/src/windows/FileChooserProxy.js
+++ b/src/windows/FileChooserProxy.js
@@ -7,9 +7,16 @@ module.exports = {
     open: function(successCallback, errorCallback, args) {
         // create picker
         var fileOpenPicker = new Windows.Storage.Pickers.FileOpenPicker();
-
+        var mimes = args[0];
+        var mimeTypesArray = mimes.mime.split(", ");
+        
+        // if no mime types are being passed, then accept all files.
+        if(mimeTypesArray.length < 1) {
+            mimeTypesArray.push('*');
+        }
+        
         // set file mask to all files
-        fileOpenPicker.fileTypeFilter.replaceAll(['*']);
+        fileOpenPicker.fileTypeFilter.replaceAll(mimeTypesArray);
         // and start location to documents library
         fileOpenPicker.suggestedStartLocation = pickerLocationId.documentsLibrary;
 

--- a/src/windows/FileChooserProxy.js
+++ b/src/windows/FileChooserProxy.js
@@ -1,0 +1,30 @@
+const pickerLocationId = Windows.Storage.Pickers.PickerLocationId;
+const pickerCancelMessage = "File uri was null"
+const pickerErrorMessage = "Error picking file!";
+
+module.exports = {
+
+    open: function(successCallback, errorCallback, args) {
+        // create picker
+        var fileOpenPicker = new Windows.Storage.Pickers.FileOpenPicker();
+
+        // set file mask to all files
+        fileOpenPicker.fileTypeFilter.replaceAll(['*']);
+        // and start location to documents library
+        fileOpenPicker.suggestedStartLocation = pickerLocationId.documentsLibrary;
+
+        // open picker async and return file path on success
+        fileOpenPicker.pickSingleFileAsync().done(function (file) {
+            if (!file || !file.path) {
+                errorCallback(pickerCancelMessage);
+                return;
+            }
+            successCallback(file.path);
+        }, function () {
+            errorCallback(pickerErrorMessage);
+        });
+    }
+
+}
+
+require('cordova/exec/proxy').add('FileChooser', module.exports);

--- a/src/windows/FileChooserProxy.js
+++ b/src/windows/FileChooserProxy.js
@@ -19,7 +19,15 @@ module.exports = {
                 errorCallback(pickerCancelMessage);
                 return;
             }
-            successCallback(file.path);
+
+            // file must be copied to local folder to be accessible by app..
+            const localFolder = Windows.Storage.ApplicationData.current.localFolder;
+            file.copyAsync(localFolder, file.name, Windows.Storage.NameCollisionOption.replaceExisting)
+            .done(function (savedFile) {
+                successCallback('ms-appdata:///local/' + savedFile.name);
+            }, function(err) {
+                errorCallback(pickerErrorMessage);
+            });
         }, function () {
             errorCallback(pickerErrorMessage);
         });

--- a/www/fileChooser.js
+++ b/www/fileChooser.js
@@ -1,5 +1,5 @@
 module.exports = {
-    open: function (success, failure) {
-        cordova.exec(success, failure, "FileChooser", "open", []);
+    open: function (filter, success, failure) {
+        cordova.exec(success, failure, "FileChooser", "open", [ filter ]);
     }
 };

--- a/www/fileChooser.js
+++ b/www/fileChooser.js
@@ -1,5 +1,11 @@
 module.exports = {
     open: function (filter, success, failure) {
+        if (typeof filter === 'function') {
+            failure = success;
+            success = filter;
+            filter = {};
+        }
+
         cordova.exec(success, failure, "FileChooser", "open", [ filter ]);
     }
 };


### PR DESCRIPTION
In windows, if the developer provided the mime-types to filter in the browsing window, these were not applied for the windows version of the plugin